### PR TITLE
remove fill words

### DIFF
--- a/docs/04-planning/02-learning-goals.adoc
+++ b/docs/04-planning/02-learning-goals.adoc
@@ -63,7 +63,7 @@ Know technical or manual approaches to explicitly represent evaluated problems a
 * Communicate and argue approaches to long-term improvement  to different stakeholders.
 
 [[LG-4-3]]
-==== LG 4-3: Assess the impact of “rewrite“ versus “continuous improvement"
+==== LG 4-3: Impact of “rewrite“ versus “continuous improvement"
 
 * Being able to assess and argue the impact (risks, benefits) of a “complete rewrite” approach in contrast to a “continuous improvement“ approach in each situation.
 

--- a/docs/05-approaches/02-learning-goals.adoc
+++ b/docs/05-approaches/02-learning-goals.adoc
@@ -2,7 +2,7 @@
 
 // tag::DE[]
 [[LZ-5-1]]
-==== LZ 5-1: Möglichkeiten zur Optimierung von Entwicklungsprozessen kennen
+==== LZ 5-1: Möglichkeiten zur Optimierung von Entwicklungsprozessen
 
 * Dezentralisierung bzw. Zentralisierung von Entwicklungsprozessen.
 * Einsatz iterativer Prozesse zur Reduktion von Risiken.
@@ -10,7 +10,7 @@
 * Identifikation kritischer Bestandteile (Personen, Organisationseinheiten) in Entwicklungsprozessen und deren Entlastung.
 
 [[LZ-5-2]]
-==== LZ 5-2: Verbesserungsmaßnahmen im Quellcode kennen und anwenden können
+==== LZ 5-2: Verbesserungsmaßnahmen im Quellcode
 
 * Für Technologien/Programmiersprachen typische Refactorings (bedeutungserhaltende Vereinfachungsmassnahmen im Quellcode) kennen und anwenden können. In Schulungen sollten bei Bedarf entsprechende Übungen durchgeführt werden.
 * Technologien besser nutzen und bessere Technologie einführen (Technologiewechsel).
@@ -19,13 +19,13 @@
 * Maßnahmen und Muster zur Verbesserung der Verständlichkeit von Quellcode kennen und anwenden können, beispielsweise Clean-Code-Prinzipien.
 
 [[LZ-5-3]]
-==== LZ 5-3: Möglichkeiten des automatisierten Tests zur Reduktion von Änderungsrisiken kennen und anwenden können
+==== LZ 5-3: Möglichkeiten des automatisierten Tests zur Reduktion von Änderungsrisiken
 
 * Automatisierte Tests (Unit-, Integrations-, Akzeptanz-, Regressionstests) als Mittel zur Früherkennung von Fehlern in Änderungs- oder Verbesserungsprojekten kennen und selbständig anwenden können (In Schulungen sollten bei Bedarf entsprechende Übungen durchgeführt werden).
 * Selbständig identifizieren können, an welchen Stellen/Schnittstellen/Komponenten die Einführung automatisierter Tests für bestimmte Änderungsszenarien angemessen ist.
 
 [[LZ-5-4]]
-==== LZ 5-4: Automatisierung als Mittel zur Reduktion von Änderungsrisiken kennen
+==== LZ 5-4: Automatisierung als Mittel zur Reduktion von Änderungsrisiken
 
 Weitere methodische und technische Mittel zur Automatisierung kennen, mit deren Hilfe systematisch Änderungsrisiken und -aufwände gesenkt werden können, beispielsweise:
 
@@ -34,23 +34,23 @@ Weitere methodische und technische Mittel zur Automatisierung kennen, mit deren 
 * Model-driven Development/Generative Development
 
 [[LZ-5-5]]
-==== LZ 5-5: Relevante Architektur-/Entwurfs- oder Implementierungsmuster zur Reduktion von Kopplung innerhalb von Systemen kennen
+==== LZ 5-5: Relevante Architektur-/Entwurfs- oder Implementierungsmuster zur Reduktion von Kopplung innerhalb von Systemen
 
 * Typische Muster zur Reduktion von Kopplung kennen und anwenden können (beispielsweise Modularisierung/Komponentenbildung, Entkopplung über Interfaces, Dependency-Injection, Kapselung, Adapter, Wrapper, Gateway), zeitliche Entkopplung über Asynchronität).
 * Effekte typischer Muster (ggfs. unter Zuhilfenahme entsprechender Werkzeuge) nachvollziehen können.
 
 [[LZ-5-6]]
-==== LZ 5-6: Technologiespezifische Möglichkeiten zur Verbesserung des Laufzeitverhaltens von Systemen kennen
+==== LZ 5-6: Technologiespezifische Möglichkeiten zur Verbesserung des Laufzeitverhaltens von Systemen
 
 Technologiespezifische Muster und Praktiken zur Verbesserung von Laufzeiteigenschaften kennen und anwenden können (die detaillierte Auswahl obliegt dem Schulungs-/Trainingsanbieter).
 
 [[LZ-5-7]]
-==== LZ 5-7: Möglichkeiten zur Verbesserung betrieblicher Prozesse kennen
+==== LZ 5-7: Möglichkeiten zur Verbesserung betrieblicher Prozesse
 
 (Unter Umständen technologiespezifische) Muster und Praktiken zur Verbesserung der Betreibbarkeit kennen (die detaillierte Auswahl obliegt dem Schulungs-/Trainingsanbieter).
 
 [[LZ-5-8]]
-==== LZ 5-8: Möglichkeiten zur Verbesserung der Dokumentation oder Dokumentationsprozesse kennen
+==== LZ 5-8: Möglichkeiten zur Verbesserung der Dokumentation oder Dokumentationsprozesse
 
 Grundlegende Möglichkeiten zur systematischen Verbesserung von technischer Dokumentation kennen und anwenden können, beispielsweise:
 
@@ -64,7 +64,7 @@ Grundlegende Möglichkeiten zur systematischen Verbesserung von technischer Doku
 
 // tag::EN[]
 [[LG-5-1]]
-==== LG 5-1: Know potential approaches to optimise development processes
+==== LG 5-1: Potential approaches to optimise development processes
 
 * Decentralisation vs. centralisation of development processes.
 * Employment of iterative processes to reduce risks.
@@ -72,7 +72,7 @@ Grundlegende Möglichkeiten zur systematischen Verbesserung von technischer Doku
 * Identify critical parts (people, organisational units) in development processes, and possible ways to relieve them.
 
 [[LG-5-2]]
-==== LG 5-2: Know and being able to apply improvement measures for source code
+==== LG 5-2: Improvement measures for source code
 
 * Know and being able to apply typical technology/programming language
 specific refactorings (semantics preserving simplification measures in source code). Trainings should conduct exercises if required.
@@ -82,13 +82,13 @@ specific refactorings (semantics preserving simplification measures in source co
 * Know and be able to apply measures and patterns to make source code more comprehensible, e. g., Clean Code principles.
 
 [[LG-5-3]]
-==== LG 5-3: Know and be able to apply possible approaches for automated testing to reduce risks of change
+==== LG 5-3: Possible approaches for automated testing to reduce risks of change
 
 * Know and being able to autonomously apply automated tests (unit-, integration-, acceptance-, regression-tests) as a means of early detection of defects in change or improvement projects. (Training should provide exercises if required.)
 * Being able to autonomously identify adequate locations/interfaces/components where the introduction of automated tests will be suitable for specific change scenarios.
 
 [[LG-5-4]]
-==== LG 5-4: Know automation as a means of reducing risks of changes
+==== LG 5-4: Automation as a means of reducing risks of changes
 
 Know further methodical and technical means of automations that may help to reduce risk and required efforts of changes, such as:
 
@@ -97,23 +97,23 @@ Know further methodical and technical means of automations that may help to redu
 * Model-driven development/generative development
 
 [[LG-5-5]]
-==== LG 5-5: Know relevant architectural-/design- or implementation patterns to reduce system-internal coupling
+==== LG 5-5: Relevant architectural-/design- or implementation patterns to reduce system-internal coupling
 
 * Know and be able to apply typical patterns to reduce coupling (e. g., modularisation/component building, decoupling via interfaces, dependency injection, encapsulation, adapter, wrapper, gateway, decoupling of control flow with asynchronous invocation).
 * Understand the impact of typical patterns (possibly by using appropriate tools).
 
 [[LG-5-6]]
-==== LG 5-6: Know technology specific options to improve the runtime behaviour of systems
+==== LG 5-6: Technology specific options to improve the runtime behaviour of systems
 
 Know and be able to apply technology specific patterns and practices to improve runtime properties (specific choices are at the training provider’s discretion).
 
 [[LG-5-7]]
-==== LG 5-7: Know options to improve operation processes
+==== LG 5-7: Options to improve operation processes
 
 (Possibly technology specific) patterns and practices to improve system operations (specific choices are at the training provider’s discretion).
 
 [[LG-5-8]]
-==== LG 5-8: Know options to improve the documentation or the documentation processes
+==== LG 5-8: Options to improve the documentation or the documentation processes
 
 Know and be able to apply basic options for systematic improvement of technical documentation, such as:
 

--- a/docs/06-examples/02-learning-goals.adoc
+++ b/docs/06-examples/02-learning-goals.adoc
@@ -8,7 +8,7 @@ Anhand konkreter Beispiele Probleme und Risiken eines mittleren/großen IT-Syste
 Dazu sollten in Schulungen mindestens dessen fachliche/funktionale Anforderungen, wesentliche Qualitätsziele, Anwendungs- und Änderungsszenarien, wesentliche Implementierungsstrukturen sowie wesentliche übergreifende Konzepte beschrieben werden.
 
 [[LZ-6-2]]
-==== LZ 6-2: Bewertung von Problemen/Risiken kennen und nachvollziehen
+==== LZ 6-2: Bewertung von Problemen/Risiken
 
 Anhand konkreter Beispiele die Bewertung (Evaluierung) von Problemen oder Lösungsansätzen nachvollziehen können.
 
@@ -33,12 +33,12 @@ Being able to identify and understand problems and risks of a medium/large IT sy
 Therefore, the trainings should at least describe the system’s main functional and non-functional requirements, quality goals, usage and change scenarios, essential implementation structures as well as important cross-cutting concepts.
 
 [[LG-6-2]]
-==== LG 6-2: Know and understand the evaluation of problems/risks
+==== LG 6-2: Evaluation of problems/risks
 
 Understand the assessment (evaluation) of problems or approaches to solutions by means of concrete examples.
 
 [[LG-6-3]]
-==== LG 6-3: Know medium- to long term planning of an improvement project
+==== LG 6-3: Medium- to long term planning of an improvement project
 
 Get to know and understand the (short-, medium- and/or long-term) planning of an improvement project by means of concrete examples.
 


### PR DESCRIPTION
Some learning goals still had some verbs that weren't really needed. Removing them improved consistency and readability of the learning goals.